### PR TITLE
Feat/fix email subscriptions

### DIFF
--- a/grabber/subscriptions/serializers/create_sub.py
+++ b/grabber/subscriptions/serializers/create_sub.py
@@ -1,15 +1,9 @@
-# subscriptions/serializers.py
-
 from rest_framework import serializers
 from subscriptions.models import NewsletterSubscriber
 
 class NewsletterSubscriberSerializer(serializers.ModelSerializer):
+    email = serializers.EmailField(required=True, validators=[])
     created_at = serializers.DateTimeField(read_only=True)
     class Meta:
         model = NewsletterSubscriber
         fields = ['email', 'created_at']
-
-    def validate_email(self, value):
-        if NewsletterSubscriber.objects.filter(email=value).exists():
-            raise serializers.ValidationError("Цей email вже підписаний.")
-        return value

--- a/grabber/subscriptions/views/subscribe.py
+++ b/grabber/subscriptions/views/subscribe.py
@@ -1,14 +1,11 @@
-# subscriptions/views.py
-
 from adrf.views import APIView
 from asgiref.sync import sync_to_async
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.response import Response
 from rest_framework import status
-
+from subscriptions.models import NewsletterSubscriber
 from subscriptions.serializers.create_sub import NewsletterSubscriberSerializer
-
 
 class SubscribeView(APIView):
     @swagger_auto_schema(
@@ -16,17 +13,29 @@ class SubscribeView(APIView):
         request_body=NewsletterSubscriberSerializer,
         responses={
             201: openapi.Response(description="Підписка успішна!"),
-            400: openapi.Response(description="Помилка валідації email або вже підписаний."),
+            409: openapi.Response(description="Ви вже підписані."),
+            400: openapi.Response(description="Помилка валідації email."),
         }
     )
     async def post(self, request):
         serializer = NewsletterSubscriberSerializer(data=request.data)
         is_valid = await sync_to_async(serializer.is_valid)()
         if is_valid:
-            await sync_to_async(serializer.save)()
-            return Response({'message': 'Підписка успішна!'}, status=status.HTTP_201_CREATED)
+            email = serializer.validated_data["email"]
+
+            subscriber, created = await sync_to_async(
+            NewsletterSubscriber.objects.get_or_create
+            )(email=email)
+
+            if not created:
+                return Response(
+                    {"message": "Ви вже підписані."},
+                    status=status.HTTP_409_CONFLICT
+                )
+
+            return Response(
+                {"message": "Підписка успішна!"},
+                status=status.HTTP_201_CREATED
+            )
+
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-
-
-
-


### PR DESCRIPTION
- Disabled default unique validator in serializer to avoid 400 on duplicate emails.
- Implemented `get_or_create` in subscription view.
- Now API returns:
  - 201 when subscription is successful
  - 409 when user is already subscribed
  - 400 for invalid email format